### PR TITLE
Use sans-serif(黑體) font instead of serif(明體) font

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css" integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/earlyaccess/notosanstc.css"/>
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <title>opendatacloud</title>
   </head>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -37,7 +37,7 @@
       </v-flex>
     </v-layout>
     <div id="wordcloud">
-      <vue-word-cloud :words="words" :color="([, weight]) => weight > 100 ? '#74482a' : weight > 50 ? '#d1b022' : weight > 20 ? '#461e47' :'#31a50d'"  :enter-animation="enter">
+      <vue-word-cloud :words="words" :color="([, weight]) => weight > 100 ? '#74482a' : weight > 50 ? '#d1b022' : weight > 20 ? '#461e47' :'#31a50d'"  :enter-animation="enter" font-family="Noto Sans TC">
         <template slot-scope="props">
 					<v-tooltip top>
 						<div


### PR DESCRIPTION
Changes made:
- Include Noto Sans TC font from Google Fonts API
- Change the VueWordCloud to use `Noto Sans TC` font.